### PR TITLE
stable setState and improved types

### DIFF
--- a/packages/use-optionally-controlled-state/src/index.tsx
+++ b/packages/use-optionally-controlled-state/src/index.tsx
@@ -1,7 +1,7 @@
-import {useState, useCallback, useRef} from 'react';
+import {useState, useCallback} from 'react';
 import useConstant from 'use-constant';
 
-export type OptionalState<Value> =
+type Options<Value> =
   | {
       controlledValue?: Value;
       initialValue: Value;
@@ -20,12 +20,12 @@ export default function useOptionallyControlledState<Value>({
   controlledValue,
   initialValue,
   onChange
-}: OptionalState<Value>): [Value, (value: Value) => void] {
+}: Options<Value>): [Value, (value: Value) => void] {
   const isControlled = controlledValue !== undefined;
   const initialIsControlled = useConstant(() => isControlled);
   const [stateValue, setStateValue] = useState(initialValue);
 
-  if (typeof __DEV__ !== 'undefined' && __DEV__) {
+  if (__DEV__) {
     if (initialValue === undefined && controlledValue === undefined) {
       throw new Error(
         'Either an initial or a controlled value should be provided.'
@@ -45,7 +45,8 @@ export default function useOptionallyControlledState<Value>({
     }
   }
 
-  const value = isControlled ? controlledValue : (stateValue as Value);
+  // Options type ensures that at either controlledValue or stateValue has a value
+  const value = (isControlled ? controlledValue : stateValue)!;
 
   const onValueChange = useCallback(
     (nextValue: Value) => {

--- a/packages/use-optionally-controlled-state/src/index.tsx
+++ b/packages/use-optionally-controlled-state/src/index.tsx
@@ -1,6 +1,18 @@
 import {useState, useCallback, useRef} from 'react';
 import useConstant from 'use-constant';
 
+export type OptionalState<Value> =
+  | {
+      controlledValue?: Value;
+      initialValue: Value;
+      onChange?(value: Value): void;
+    }
+  | {
+      controlledValue: Value;
+      initialValue?: Value;
+      onChange?(value: Value): void;
+    };
+
 /**
  * Enables a component state to be either controlled or uncontrolled.
  */
@@ -8,16 +20,12 @@ export default function useOptionallyControlledState<Value>({
   controlledValue,
   initialValue,
   onChange
-}: {
-  controlledValue?: Value;
-  initialValue?: Value;
-  onChange?(value: Value): void;
-}): [Value | undefined, (value: Value) => void] {
+}: OptionalState<Value>): [Value, (value: Value) => void] {
   const isControlled = controlledValue !== undefined;
   const initialIsControlled = useConstant(() => isControlled);
   const [stateValue, setStateValue] = useState(initialValue);
 
-  if (__DEV__) {
+  if (typeof __DEV__ !== 'undefined' && __DEV__) {
     if (initialValue === undefined && controlledValue === undefined) {
       throw new Error(
         'Either an initial or a controlled value should be provided.'
@@ -37,7 +45,7 @@ export default function useOptionallyControlledState<Value>({
     }
   }
 
-  const value = isControlled ? controlledValue : stateValue;
+  const value = isControlled ? controlledValue : (stateValue as Value);
 
   const isControlledRef = useRef(false);
   isControlledRef.current = isControlled;

--- a/packages/use-optionally-controlled-state/src/index.tsx
+++ b/packages/use-optionally-controlled-state/src/index.tsx
@@ -1,4 +1,4 @@
-import {useState} from 'react';
+import {useState, useCallback, useRef} from 'react';
 import useConstant from 'use-constant';
 
 /**
@@ -39,10 +39,15 @@ export default function useOptionallyControlledState<Value>({
 
   const value = isControlled ? controlledValue : stateValue;
 
-  function onValueChange(nextValue: Value) {
-    if (!isControlled) setStateValue(nextValue);
-    if (onChange) onChange(nextValue);
-  }
+  const isControlledRef = useRef(false);
+  isControlledRef.current = isControlled;
+  const onValueChange = useCallback(
+    (nextValue: Value) => {
+      if (!isControlledRef.current) setStateValue(nextValue);
+      if (onChange) onChange(nextValue);
+    },
+    [onChange]
+  );
 
   return [value, onValueChange];
 }

--- a/packages/use-optionally-controlled-state/src/index.tsx
+++ b/packages/use-optionally-controlled-state/src/index.tsx
@@ -45,7 +45,7 @@ export default function useOptionallyControlledState<Value>({
     }
   }
 
-  // Options type ensures that at either controlledValue or stateValue has a value
+  // Options type ensures that either `controlledValue` or `stateValue` is defined
   const value = (isControlled ? controlledValue : stateValue)!;
 
   const onValueChange = useCallback(

--- a/packages/use-optionally-controlled-state/src/index.tsx
+++ b/packages/use-optionally-controlled-state/src/index.tsx
@@ -47,14 +47,12 @@ export default function useOptionallyControlledState<Value>({
 
   const value = isControlled ? controlledValue : (stateValue as Value);
 
-  const isControlledRef = useRef(false);
-  isControlledRef.current = isControlled;
   const onValueChange = useCallback(
     (nextValue: Value) => {
-      if (!isControlledRef.current) setStateValue(nextValue);
+      if (!isControlled) setStateValue(nextValue);
       if (onChange) onChange(nextValue);
     },
-    [onChange]
+    [onChange, isControlled]
   );
 
   return [value, onValueChange];


### PR DESCRIPTION
- stable setState - wrap method with useCallback, to reuse the same value (mabye I should put `onChange` to be more consistent with `setState`?)
- improve types - usage is now forced to supply either `initialValue` or `controlledValue`, return type is Value, which also works when setting `initialValue: undefined` or `controlledValue: undefined`